### PR TITLE
fix: handle None host.cluster and entity_parent_uuid in v4 API response

### DIFF
--- a/nutanix_prometheus_exporter.py
+++ b/nutanix_prometheus_exporter.py
@@ -3780,6 +3780,9 @@ def v4_get_entity_stats(client,module,entity_api,function,entity,metric_key_pref
     start_time = (datetime.now(timezone.utc) - timedelta(seconds=150)).isoformat()
     end_time = (datetime.now(timezone.utc)).isoformat()
     if 'entity_parent_uuid' in entity:
+        if entity['entity_parent_uuid'] is None:
+            print(f"{PrintColors.WARNING}{(datetime.now()).strftime('%Y-%m-%d %H:%M:%S')} [WARNING] Skipping {function} for entity {entity.get('entity_name','unknown')} — no parent cluster UUID{PrintColors.RESET}")
+            return []
         response = get_stats_function(entity['entity_parent_uuid'],extId=entity['entity_uuid'], _startTime=start_time, _endTime=end_time, _samplingInterval=sampling_interval, _statType=stat_type, _select='*')
     else:
         response = get_stats_function(extId=entity['entity_uuid'], _startTime=start_time, _endTime=end_time, _samplingInterval=sampling_interval, _statType=stat_type, _select='*')
@@ -3852,6 +3855,9 @@ def v4_get_files_analytics_stats(client,module,entity_api,function,entity,metric
     start_time = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
     end_time = (datetime.now(timezone.utc)).isoformat()
     if 'entity_parent_uuid' in entity:
+        if entity['entity_parent_uuid'] is None:
+            print(f"{PrintColors.WARNING}{(datetime.now()).strftime('%Y-%m-%d %H:%M:%S')} [WARNING] Skipping {function} for entity {entity.get('entity_name','unknown')} — no parent cluster UUID{PrintColors.RESET}")
+            return []
         response = get_stats_function(entity['entity_parent_uuid'],extId=entity['entity_uuid'], _startTime=start_time, _endTime=end_time, _samplingInterval=sampling_interval, _select='*')
     else:
         response = get_stats_function(extId=entity['entity_uuid'], _startTime=start_time, _endTime=end_time, _samplingInterval=sampling_interval, _select='*')

--- a/nutanix_prometheus_exporter.py
+++ b/nutanix_prometheus_exporter.py
@@ -958,7 +958,7 @@ class NutanixMetrics:
                 host_list = v4_get_all_entities(module=ntnx_clustermgmt_py_client,client=clustermgmt_client,function='list_hosts',limit=limit,module_entity_api='ClustersApi')
             for cluster in cluster_list:
                 if 'PRISM_CENTRAL' not in cluster.config.cluster_function:
-                    cluster_hosts_list = [host for host in host_list if host.cluster.uuid == cluster.ext_id]
+                    cluster_hosts_list = [host for host in host_list if host.cluster is not None and host.cluster.uuid == cluster.ext_id]
                     self.__dict__["nutanix_count_node"].labels(entity=cluster.name).set(len(cluster_hosts_list))
             #endregion host
 
@@ -1018,7 +1018,7 @@ class NutanixMetrics:
                 entity_details = {
                     'entity_name': entity.host_name,
                     'entity_uuid': entity.ext_id,
-                    'entity_parent_uuid': entity.cluster.uuid,
+                    'entity_parent_uuid': entity.cluster.uuid if entity.cluster is not None else None,
                 }
                 #print(entity_details)
                 host_details_list.append(entity_details)
@@ -3950,6 +3950,7 @@ def v4_init_api_client(module, prism, user, pwd, prism_secure=False):
 
     api_client_configuration = module.Configuration()
     api_client_configuration.host = prism
+    api_client_configuration.port = 9440
     api_client_configuration.username = user
     api_client_configuration.password = pwd
 


### PR DESCRIPTION
When a host has no cluster association (e.g. maintenance mode, decommissioning
or ghost entries in Prism Central), the v4 API returns cluster=None.

This caused two issues:
1. AttributeError crash when filtering hosts by cluster UUID
2. "Missing required parameter clusterExtId" error when fetching host stats

Fixes:
- Guard against None in cluster_hosts_list filter (line 961)
- Guard against None in entity_details host parent UUID (line 1021)
- Skip get_host_stats/get_files_analytics_stats gracefully when entity_parent_uuid is None

Tested on Nutanix Prism Central 7.5.0.6 with hosts in ghost/unassigned state.