### PR TITLE
fix: filter None entities from v4 API paginated responses

### DIFF
--- a/nutanix_prometheus_exporter.py
+++ b/nutanix_prometheus_exporter.py
@@ -3685,7 +3685,7 @@ def v4_get_all_entities(module,client,function,limit,module_entity_api,parent_en
         print(f"{PrintColors.WARNING}{(datetime.now()).strftime('%Y-%m-%d %H:%M:%S')} [WARNING] No entities found for {function} in {module_entity_api}!{PrintColors.RESET}")
     for error in error_list:
         print(error)
-    return entity_list
+    return [e for e in entity_list if e is not None]
 
 
 def v4_get_subnets(client,module,entity_api,function,page,limit=50):
@@ -3755,7 +3755,7 @@ def v4_get_all_subnets(client,limit):
         print(f"{PrintColors.WARNING}{(datetime.now()).strftime('%Y-%m-%d %H:%M:%S')} [WARNING] No entities found for list_subnets in SubnetsApi!{PrintColors.RESET}")
     for error in error_list:
         print(error)
-    return entity_list
+    return [e for e in entity_list if e is not None]
 
 
 def v4_get_entity_stats(client,module,entity_api,function,entity,metric_key_prefix,sampling_interval,stat_type):


### PR DESCRIPTION
The Nutanix v4 API can return None entries in paginated entity lists. This was observed with list_tasks but could affect any entity type. When the exporter iterates over these lists and accesses attributes (e.g. task.status),
it crashes with AttributeError: 'NoneType' object has no attribute 'status'.

The fix filters out None entries in v4_get_all_entities() and v4_get_all_subnets() before returning the list, so all downstream metric processing is protected regardless of entity type.

python
return [e for e in entity_list if e is not None]
